### PR TITLE
Enhance reasoningEffort support and output token capping in streaming service

### DIFF
--- a/lib/openproviders/index.ts
+++ b/lib/openproviders/index.ts
@@ -111,16 +111,27 @@ export function openproviders<T extends SupportedModel>(
       ? {
           ...openaiSettings,
           openai: {
+            // For GPT-5 and reasoning models, prefer provider-level options
             textVerbosity: textVerbosity || verbosity || 'low',
             reasoningSummary: reasoningSummary ?? 'auto',
             serviceTier: serviceTier || 'auto',
             parallelToolCalls: merged.parallelToolCalls ?? true,
             store: merged.store ?? false,
             previousResponseId: merged.previousResponseId,
+            // Pass through reasoningEffort when available
+            ...(reasoningEffort ? { reasoningEffort } : {}),
             ...(openaiSettings.openai || {}),
           },
         }
-      : openaiSettings;
+      : // Non-GPT5 OpenAI models still accept providerOptions.openai
+        // (AI SDK forwards these to the provider);
+        // include reasoningEffort if set
+        ({
+          ...openaiSettings,
+          ...(reasoningEffort
+            ? { openai: { reasoningEffort, ...(openaiSettings.openai || {}) } }
+            : {}),
+        } as Record<string, unknown>);
 
     // Configure file search tools if enabled
     const _tools =


### PR DESCRIPTION
## Summary
- Adds support for passing `reasoningEffort` option in OpenProviders configuration for GPT-5 and reasoning models
- Caps output tokens in StreamingService based on `reasoningEffort` to reduce latency
- Includes reasoning tokens in metrics reporting

## Changes

### OpenProviders
- For GPT-5 and reasoning models, provider-level options now include `reasoningEffort` when available
- For non-GPT5 OpenAI models, `reasoningEffort` is passed through under `openai` options if set

### StreamingService
- Introduced heuristic to cap `maxOutputTokens` based on `reasoningEffort`:
  - `high` effort caps at 1200 tokens
  - `low` effort caps at 500 tokens
  - default/medium caps at 800 tokens
- Added `maxOutputTokens` parameter to `streamText` call
- Enhanced metrics to include `reasoningTokens` from provider metadata

## Test plan
- Verified that `reasoningEffort` is correctly passed in provider options for GPT-5 and other models
- Confirmed output token limits adjust according to `reasoningEffort` setting
- Checked metrics logging includes reasoning tokens when available
- Ensured no regressions in streaming and provider configuration behavior

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/0110c72a-212b-497a-975c-df8c8cb9aad1