### PR TITLE
Add default 'gpt-5-mini' as favorite model and unify temperature handling

### DIFF
--- a/.claude-flow/metrics/performance.json
+++ b/.claude-flow/metrics/performance.json
@@ -1,5 +1,5 @@
 {
-  "startTime": 1756505910348,
+  "startTime": 1756736342001,
   "totalTasks": 1,
   "successfulTasks": 1,
   "failedTasks": 0,

--- a/.claude-flow/metrics/task-metrics.json
+++ b/.claude-flow/metrics/task-metrics.json
@@ -1,10 +1,10 @@
 [
   {
-    "id": "cmd-hooks-1756505910646",
+    "id": "cmd-hooks-1756736342390",
     "type": "hooks",
     "success": true,
-    "duration": 14.11445900000001,
-    "timestamp": 1756505910661,
+    "duration": 62.82029,
+    "timestamp": 1756736342454,
     "metadata": {}
   }
 ]

--- a/app/api/user-preferences/favorite-models/route.ts
+++ b/app/api/user-preferences/favorite-models/route.ts
@@ -107,7 +107,7 @@ export async function GET() {
     }
 
     return NextResponse.json({
-      favorite_models: (data as any).favorite_models || [],
+      favorite_models: (data as any).favorite_models || ['gpt-5-mini'],
     });
   } catch {
     return NextResponse.json(

--- a/components/app/layout/settings/models/use-favorite-models.ts
+++ b/components/app/layout/settings/models/use-favorite-models.ts
@@ -16,10 +16,10 @@ export function useFavoriteModels() {
     useModel();
   const { refreshUser } = useUser();
 
-  // Ensure we always have an array
-  const safeInitialData = Array.isArray(initialFavoriteModels)
+  // Ensure we always have an array with default gpt-5-mini
+  const safeInitialData = Array.isArray(initialFavoriteModels) && initialFavoriteModels.length > 0
     ? initialFavoriteModels
-    : [];
+    : ['gpt-5-mini'];
 
   // Query to fetch favorite models
   const {
@@ -38,7 +38,7 @@ export function useFavoriteModels() {
       }
 
       const data: FavoriteModelsResponse = await response.json();
-      return data.favorite_models || [];
+      return data.favorite_models || ['gpt-5-mini'];
     },
     staleTime: 5 * 60 * 1000, // 5 minutes
     retry: 1,

--- a/lib/model-store/provider.tsx
+++ b/lib/model-store/provider.tsx
@@ -102,7 +102,7 @@ export function ModelProvider({ children }: { children: React.ReactNode }) {
     refetchOnWindowFocus: false,
   });
 
-  const { data: favoriteModels = [], isLoading: isLoadingFavorites } = useQuery<
+  const { data: favoriteModels = ['gpt-5-mini'], isLoading: isLoadingFavorites } = useQuery<
     string[]
   >({
     queryKey: ['favorite-models'],
@@ -112,12 +112,12 @@ export function ModelProvider({ children }: { children: React.ReactNode }) {
           '/api/user-preferences/favorite-models'
         );
         if (!response.ok) {
-          return [];
+          return ['gpt-5-mini'];
         }
         const data = await response.json();
-        return data.favorite_models || [];
+        return data.favorite_models || ['gpt-5-mini'];
       } catch {
-        return [];
+        return ['gpt-5-mini'];
       }
     },
     staleTime: 5 * 60 * 1000, // 5 minutes

--- a/lib/services/ChatService.ts
+++ b/lib/services/ChatService.ts
@@ -17,6 +17,7 @@ import { retrieveWithGpt41 } from '@/lib/retrieval/two-pass';
 import { performVectorRetrieval } from '@/lib/retrieval/vector-retrieval';
 import { file_search } from '@/lib/tools/file-search';
 import logger from '@/lib/utils/logger';
+import { getModelTemperature } from '@/lib/models/temperature-utils';
 import { CredentialService } from './CredentialService';
 import { LangSmithService } from './LangSmithService';
 import { MessageService } from './MessageService';
@@ -359,7 +360,7 @@ export class ChatService {
           enableSearch,
           reasoningEffort,
           verbosity,
-          temperature: isGPT5Model ? 1 : undefined,
+          temperature: getModelTemperature(resolvedModel),
           fileSearchToolsCapable: modelSupportsFileSearchTools,
         },
         'chat request'

--- a/lib/services/StreamingService.ts
+++ b/lib/services/StreamingService.ts
@@ -11,6 +11,7 @@ import {
   type ReasoningContext,
 } from '@/lib/middleware/extract-reasoning-middleware';
 import logger from '@/lib/utils/logger';
+import { getModelTemperature } from '@/lib/models/temperature-utils';
 import { type Provider, trackCredentialUsage } from '@/lib/utils/metrics';
 import { storeAssistantMessage } from '../../app/api/chat/api';
 import type { ResponseWithUsage, SupabaseClientType } from './types';
@@ -295,7 +296,7 @@ const stream = ({
     ...(shouldForceFileSearch
       ? { toolChoice: { type: 'tool', toolName: 'file_search' as const } }
       : {}),
-    temperature: isGPT5Model ? 1 : undefined,
+    temperature: getModelTemperature(resolvedModel),
     maxOutputTokens,
     onError: () => {
       logger.warn(


### PR DESCRIPTION
## Summary
- Sets 'gpt-5-mini' as the default favorite model across user preferences and UI components
- Ensures fallback to 'gpt-5-mini' when no favorite models are found or API calls fail
- Refactors temperature setting logic to use `getModelTemperature` utility for GPT-5 and other models

## Changes

### Favorite Models Handling
- Updated API route to return ['gpt-5-mini'] if no favorite models exist
- Modified React hooks and providers to default to ['gpt-5-mini'] when initial data is empty or fetch fails

### Temperature Configuration
- Replaced hardcoded temperature logic for GPT-5 models with `getModelTemperature` utility in ChatService and StreamingService

### Miscellaneous
- Minor updates to performance and task metrics JSON files (timestamps and durations)

## Test plan
- [x] Verify that the favorite models API returns ['gpt-5-mini'] by default
- [x] Confirm UI components load with 'gpt-5-mini' as the default favorite model
- [x] Test chat and streaming services apply correct temperature settings based on model
- [x] Ensure no regressions in fetching and displaying favorite models
- [x] Validate that metrics files updates do not affect functionality

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/e6229d67-d441-4760-8838-2283e0c54b1e