### PR TITLE
Fix chat response handling and default verbosity settings

### DIFF
--- a/components/app/chat-input/chat-input.tsx
+++ b/components/app/chat-input/chat-input.tsx
@@ -18,8 +18,7 @@ import {
 } from '../chat/reasoning-effort-selector';
 import { PromptSystem } from '../suggestions/prompt-system';
 import { ButtonFileUpload } from './button-file-upload';
-import { VerbositySelector } from '../chat/verbosity-selector';
-import { ReasoningSummarySelector } from '../chat/reasoning-summary-selector';
+// Verbosity and summary controls are hidden; defaults are applied server-side
 // Search is always enabled; toggle removed
 import { FileList } from './file-list';
 
@@ -211,7 +210,7 @@ export function ChatInput({
   // Determine if selected model supports reasoning
   const selectedModelInfo = getModelInfo(selectedModel);
   const showReasoningEffort = Boolean(selectedModelInfo?.reasoningText);
-  const showVerbosity = showReasoningEffort;
+  const showVerbosity = false; // Hidden: default short verbosity and auto summaries
 
   return (
     <div className="relative flex w-full flex-col gap-4">
@@ -257,20 +256,7 @@ export function ChatInput({
                   value={currentReasoningEffort}
                 />
               )}
-              {showVerbosity && (
-                <VerbositySelector
-                  className="rounded-full"
-                  onChange={(v) => onVerbosityChange?.(v)}
-                  value={verbosity || 'medium'}
-                />
-              )}
-              {showVerbosity && (
-                <ReasoningSummarySelector
-                  className="rounded-full"
-                  onChange={(v) => onReasoningSummaryChange?.(v)}
-                  value={reasoningSummary || 'auto'}
-                />
-              )}
+              {/* Verbosity/Summary controls removed from UI */}
             </div>
             <div className="flex items-center gap-2">
               {status === 'streaming' || (value && !isOnlyWhitespace(value)) ? (

--- a/components/app/chat/chat-business-logic.ts
+++ b/components/app/chat/chat-business-logic.ts
@@ -186,7 +186,8 @@ export async function submitMessageScenario(
         systemPrompt: systemPrompt || SYSTEM_PROMPT_DEFAULT,
         enableSearch,
         reasoningEffort,
-        verbosity: context.verbosity ?? 'medium',
+        // Default to short responses
+        verbosity: context.verbosity ?? 'low',
         reasoningSummary: context.reasoningSummary ?? 'auto',
         context: 'chat' as const, // Explicitly set chat context for immediate response
       },
@@ -370,7 +371,8 @@ export async function submitSuggestionScenario(
         isAuthenticated,
         systemPrompt: SYSTEM_PROMPT_DEFAULT,
         reasoningEffort,
-        verbosity: context.verbosity ?? 'medium',
+        // Default to short responses
+        verbosity: context.verbosity ?? 'low',
         reasoningSummary: context.reasoningSummary ?? 'auto',
         context: 'chat' as const, // Explicitly set chat context for immediate response
       },

--- a/components/app/chat/use-chat-core.ts
+++ b/components/app/chat/use-chat-core.ts
@@ -67,8 +67,9 @@ export function useChatCore({
   const [reasoningEffort, setReasoningEffort] = useState<
     'low' | 'medium' | 'high'
   >('medium');
+  // Default to short responses by design
   const [verbosity, setVerbosity] = useState<'low' | 'medium' | 'high'>(
-    'medium'
+    'low'
   );
   const [reasoningSummary, setReasoningSummary] = useState<
     'auto' | 'detailed'

--- a/lib/services/ChatService.ts
+++ b/lib/services/ChatService.ts
@@ -57,7 +57,8 @@ export class ChatService {
         enableSearch,
         message_group_id,
         reasoningEffort = 'medium',
-        verbosity = 'medium',
+        // Default short verbosity across models
+        verbosity = 'low',
         reasoningSummary = 'auto',
         context = 'chat',
         personalityMode,


### PR DESCRIPTION
## Summary
- Fixes message content extraction to handle both v4 and v5 message formats including streaming text deltas
- Removes verbosity and reasoning summary controls from the chat input UI, applying default short verbosity and auto summaries server-side
- Sets default verbosity to 'low' (short responses) across chat core, business logic, and chat service layers

## Changes

### Message Content Handling
- Updated `getMessageContent` to aggregate text from message parts, supporting both consolidated text and streaming delta formats

### UI Components
- Removed `VerbositySelector` and `ReasoningSummarySelector` from `ChatInput` component UI
- Hardcoded `showVerbosity` to false to hide verbosity and summary controls

### Chat Business Logic
- Default verbosity changed from 'medium' to 'low' in message submission and suggestion scenarios

### Chat Core Hook
- Default verbosity state initialized to 'low' instead of 'medium'

### Chat Service
- Default verbosity parameter set to 'low' to ensure consistent short responses across models

## Test plan
- Verify chat messages correctly display full content from both v4 and v5 message formats
- Confirm verbosity and reasoning summary controls are no longer visible in chat input UI
- Test chat responses default to short verbosity without user selection
- Validate no regressions in message submission and suggestion flows with updated verbosity defaults

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/193ad6d9-f065-4ea1-8516-37a4fa5d2a23