### PR TITLE
fix: prevent premature redirect on first message submission

### DIFF
--- a/components/app/chat/use-chat-core.ts
+++ b/components/app/chat/use-chat-core.ts
@@ -188,6 +188,8 @@ export function useChatCore({
 
   // Submit action using BDD-style operations
   const submit = useCallback(async () => {
+    // Prevent premature redirect while submitting the first message
+    hasSentFirstMessageRef.current = true;
     setIsSubmitting(true);
 
     const currentInput = inputValue;
@@ -285,6 +287,8 @@ export function useChatCore({
   // Handle suggestion using BDD-style operations
   const handleSuggestion = useCallback(
     async (suggestion: string) => {
+      // Prevent premature redirect while submitting the first suggestion
+      hasSentFirstMessageRef.current = true;
       setIsSubmitting(true);
 
       try {


### PR DESCRIPTION
## Summary
- Fixes an issue where the chat UI prematurely redirects while submitting the first message or suggestion
- Ensures the `hasSentFirstMessageRef` flag is set to true on first submit or suggestion to prevent redirect

## Changes

### Core Functionality
- Updated `submit` function in `use-chat-core.ts` to set `hasSentFirstMessageRef.current = true` before submission
- Updated `handleSuggestion` function in `use-chat-core.ts` to also set `hasSentFirstMessageRef.current = true` before processing suggestions

## Test plan
- [ ] Verify that submitting the first message does not cause premature redirect
- [ ] Verify that submitting the first suggestion does not cause premature redirect
- [ ] Confirm normal chat flow and UI behavior after first message submission

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/65462e12-751a-404a-b48a-e8f89b1e8bba