### PR TITLE
fix: set hasSentFirstMessageRef to true before sending messages

### DIFF
--- a/.claude-flow/metrics/performance.json
+++ b/.claude-flow/metrics/performance.json
@@ -1,5 +1,5 @@
 {
-  "startTime": 1756823162925,
+  "startTime": 1756862171310,
   "totalTasks": 1,
   "successfulTasks": 1,
   "failedTasks": 0,

--- a/.claude-flow/metrics/task-metrics.json
+++ b/.claude-flow/metrics/task-metrics.json
@@ -1,10 +1,10 @@
 [
   {
-    "id": "cmd-hooks-1756823163176",
+    "id": "cmd-hooks-1756862171508",
     "type": "hooks",
     "success": true,
-    "duration": 43.84512099999995,
-    "timestamp": 1756823163220,
+    "duration": 33.46821300000005,
+    "timestamp": 1756862171542,
     "metadata": {}
   }
 ]

--- a/components/app/chat/use-chat-core.ts
+++ b/components/app/chat/use-chat-core.ts
@@ -234,6 +234,9 @@ export function useChatCore({
       if (!result.data) return;
       const { chatId: currentChatId, requestOptions } = result.data;
 
+      // Set guard ref before sending
+      hasSentFirstMessageRef.current = true;
+
       // In v5, use sendMessage which handles everything including optimistic updates
       // v5 expects an object with text property. Optionally attach guest BYOK headers (session scope).
       try {
@@ -322,6 +325,9 @@ export function useChatCore({
         // Operation succeeded - proceed with sendMessage
         if (!result.data) return;
         const { requestOptions } = result.data;
+
+        // Set guard ref before sending
+        hasSentFirstMessageRef.current = true;
 
         // v5 sendMessage expects an object with text property for proper formatting
         await sendMessage({ text: suggestion }, requestOptions);


### PR DESCRIPTION
## Summary
- Fixes chat response UI by setting `hasSentFirstMessageRef.current` to `true` before sending messages
- Ensures proper state management for first message sent guard in chat core

## Changes

### Core Functionality
- Updated `useChatCore` hook to set `hasSentFirstMessageRef.current = true` before calling `sendMessage` in two places:
  - When sending the initial message
  - When sending a suggestion message

### Metrics
- Updated performance and task metrics timestamps and durations (non-functional changes)

## Test plan
- [x] Verify that the first message sent guard is correctly set before sending messages
- [x] Confirm chat UI updates correctly after sending messages
- [x] Ensure no regressions in message sending flow
- [x] Validate metrics updates do not affect functionality

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/6106c502-63e5-4a31-a58e-b13fc5418ace